### PR TITLE
Allow Mac/Chrome search selects to have same height as inputs.

### DIFF
--- a/libsite7b/css/header-from-embedded.css
+++ b/libsite7b/css/header-from-embedded.css
@@ -427,6 +427,7 @@ max-width: 100%; /* to override existing style */
 #catalog-options, #journals-options {
   display: none;
   height: 50px;
+  -webkit-appearance: none;
 }
 #internal-search #catalog-options, #internal-search #journals-options {
   height: 38px;

--- a/libsite7b/templates/lai-header-in-search.php
+++ b/libsite7b/templates/lai-header-in-search.php
@@ -225,6 +225,7 @@
 
   #catalog-options, #journals-options {
     display: none;
+    -webkit-appearance: none;
   }
 
   #search-dropdown, #search-dropdown li {


### PR DESCRIPTION
Fixes #36.