### PR TITLE
position scope list below triangle in triangle-only case, and have triangle click be toggle instead of just open

### DIFF
--- a/libsite7b/css/header.css
+++ b/libsite7b/css/header.css
@@ -408,6 +408,9 @@ Setting text-size-adjust to 100% didn't seem to fix things, so setting a max-wid
     width: 2em;
     white-space: nowrap;
   }
+  #scope-dropdown ul {
+    top: 100%;
+  }
   #current-scope {
     outline: none;
     font-size: 0;

--- a/libsite7b/templates/lai-header.php
+++ b/libsite7b/templates/lai-header.php
@@ -356,7 +356,12 @@ function searchDropdown(passedThis) {
 }
 
 jQuery("#current-scope").on("click", function() {
-  jQuery("#scope-dropdown ul").show();
+  var scopeList = jQuery("#scope-dropdown ul");
+  if (scopeList.is(":hidden")) {
+    scopeList.show();
+  } else {
+    scopeList.hide();
+  }
   hideAutocomplete();
 });
 


### PR DESCRIPTION
Based on Robin's latest comment on #153, I'm pull-requesting the change that would make the list of full scopes show up vertically below the triangle, instead of on directly on top of it (covering it), for the cases where there's not enough room to display the full text so we just show the triangle. As well as the change that makes clicking the triangle toggle the scope list on (show) and off (hide), since the triangle is now visible at all times instead of being covered (so previously clicking the triangle only had to show the list).

Pull requesting again to the testing-for-9-24-release branch (oops, a little late!) so that this branch's code can be put on test server.