### PR TITLE
Add GDPR cookie notice and styling

### DIFF
--- a/libsite7b/css/eu-cookie-compliance-overrides.css
+++ b/libsite7b/css/eu-cookie-compliance-overrides.css
@@ -1,0 +1,52 @@
+#popup-text a, #popup-text strong {
+  color: #fff;
+}
+#popup-text a {
+  text-decoration: underline;
+}
+
+#sliding-popup .popup-content {
+  margin: 0 auto;
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+}
+#sliding-popup .popup-content #popup-text {
+  max-width: 80%;
+}
+@media screen and (max-width: 800px) {
+  #sliding-popup .popup-content #popup-text {
+    max-width: 95%;
+  }
+}
+#sliding-popup .popup-content #popup-text p {
+  font-size: 17px;
+  margin: 1em 0;
+  display: block;
+  line-height: 1.5em;
+}
+@media screen and (max-width: 800px) {
+  #sliding-popup .popup-content #popup-text p {
+    font-size: 15px;
+    margin: 0.5em 0 0;
+    line-height: 1.35em;
+  }
+}
+
+#sliding-popup #popup-buttons button {
+  font-family: inherit;
+  font-weight: normal;
+  background-color: #fff;
+  border-color: #004065;
+  padding: 5px 12px;
+  color: #004065;
+  display: inline-block;
+  margin: 0 1em;
+}
+@media screen and (max-width: 800px) {
+  #sliding-popup #popup-buttons button {
+    font-size: 15px;
+  }
+}

--- a/libsite7b/css/style.css
+++ b/libsite7b/css/style.css
@@ -1,6 +1,7 @@
 @charset "utf-8";
 @import "google-cse.css";
 @import "vision.css";
+@import "eu-cookie-compliance-overrides.css";
 
 @import "editorial/meanmenu.css";
 @import "editorial/gwu-proto-nice-menu.css";


### PR DESCRIPTION
To add the cookie notice and make it look nice, do the following:

 1. **Add theme changes from this branch** (includes a new CSS file and its import from an already incorporated CSS file). Refs #168.
 1. **Install the EU Cookie Compliance Drupal module.** From the Drupal site root:
     1. Temporarily open permissions: `sudo chmod 775 sites/all/modules/`
     1. Enable the module: `drush en eu_cookie_compliance`. Probably have to click  `y` and `y` to proceed.
     1. Reset permissions (this assumes `fix-permissions.sh` is one directory up): `sudo bash ../fix-permissions.sh --drupal_path=/FULL/PATH/TO/DRUPAL/SITE/ROOT --drupal_user=www-data`
     1. `drush cc all` to clear cache
 1. **Change the module's configuration** (differences from default below):
    * In the browser go to `/admin/config/system/eu-cookie-compliance`
    * Uncheck all roles except for **`anonymous user`**
    * Select the _"Consent by default. Don't provide any option to opt out."_ radio button
    * For the _"Cookie information banner message"_ field
       * change the Text Format to "Full HTML".
       * click the "Source" button and paste in: `<p>GW uses cookies and other technology on our websites to improve your website experience and to better understand how you use our websites. Visit GW’s <a href="https://www.gwu.edu/privacy-notice" target="_blank">Website Privacy Notice</a> to learn more about how GW uses cookies and, if you should choose, how to disable them. I understand that by clicking <strong>“I consent”</strong> and continuing to use this website, I agree to GW’s use of cookies.</p>`
    * In the _"Agree button label"_ field, enter **`I consent.`**
    * Uncheck the _'Show "Cookie policy" and "More info" buttons'_ checkbox.
    * In the _"Thank you banner message"_ field, also change the Text Format to "Full HTML" and paste in `<p>Thank you for accepting cookies. You can now hide this message.</p>` in the Source, but do **NOT** check the _'Enable "Thank you" banner '_ checkbox.
    * In the _"Privacy policy link"_ field enter **`https://www.gwu.edu/privacy-notice`**
    * In the _"Background color"_ field enter **`0073aa`**
    * Click _"Advanced"_.
       * Check _"Let screen readers see the banner before other links on the page."_
       * In the _"Domain"_ field (not the _"Domain list"_ field), enter **gwu.edu** (or **wrlc.org** if testing locally)
    * Click "Save configuration"
  1. **Probably need to clear cache again.**