### PR TITLE
Release 002 (GDPR cookie notice, tested w/ XSS fix and module updates)

### DIFF
--- a/libsite7b/css/eu-cookie-compliance-overrides.css
+++ b/libsite7b/css/eu-cookie-compliance-overrides.css
@@ -1,0 +1,52 @@
+#popup-text a, #popup-text strong {
+  color: #fff;
+}
+#popup-text a {
+  text-decoration: underline;
+}
+
+#sliding-popup .popup-content {
+  margin: 0 auto;
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+}
+#sliding-popup .popup-content #popup-text {
+  max-width: 80%;
+}
+@media screen and (max-width: 800px) {
+  #sliding-popup .popup-content #popup-text {
+    max-width: 95%;
+  }
+}
+#sliding-popup .popup-content #popup-text p {
+  font-size: 17px;
+  margin: 1em 0;
+  display: block;
+  line-height: 1.5em;
+}
+@media screen and (max-width: 800px) {
+  #sliding-popup .popup-content #popup-text p {
+    font-size: 15px;
+    margin: 0.5em 0 0;
+    line-height: 1.35em;
+  }
+}
+
+#sliding-popup #popup-buttons button {
+  font-family: inherit;
+  font-weight: normal;
+  background-color: #fff;
+  border-color: #004065;
+  padding: 5px 12px;
+  color: #004065;
+  display: inline-block;
+  margin: 0 1em;
+}
+@media screen and (max-width: 800px) {
+  #sliding-popup #popup-buttons button {
+    font-size: 15px;
+  }
+}

--- a/libsite7b/css/style.css
+++ b/libsite7b/css/style.css
@@ -1,6 +1,7 @@
 @charset "utf-8";
 @import "google-cse.css";
 @import "vision.css";
+@import "eu-cookie-compliance-overrides.css";
 
 @import "editorial/meanmenu.css";
 @import "editorial/gwu-proto-nice-menu.css";

--- a/release-notes.md
+++ b/release-notes.md
@@ -7,3 +7,6 @@ For intended release 2018/10/08
 
 For intended release 2018/12/03
 * Update Eckles menu items (fixes [158](../../issues/158))
+
+For intended release 2018/02/28
+* GDPR-related cookie notice (styling overrides from the eu_cookie_compliance module) (fixes [168](../../issues/168))

--- a/release-notes.md
+++ b/release-notes.md
@@ -8,5 +8,5 @@ For intended release 2018/10/08
 For intended release 2018/12/03
 * Update Eckles menu items (fixes [158](../../issues/158))
 
-For intended release 2018/02/28
+For intended release 2018/03/05
 * GDPR-related cookie notice (styling overrides from the eu_cookie_compliance module) (fixes [168](../../issues/168))


### PR DESCRIPTION
This release just includes the one theme change:
 * Fixes #168 (GDPR/cookie notice styling)

That was regression tested and feature tested (and passed) alongside the following changes in other repos or non-repo'ed:
 * Removal of orphaned actions
 * gwu-libraries/Drupal-Modules#145 smaller XSS vulnerability on /events pages
 * Updates of the following modules: drupal (aka core), addtoany, ctools, google_analytics, honeypot, linkchecker, services, scanner, views_datasource, and webform.