### PR TITLE
T172 events ugly wrapping

### DIFF
--- a/libsite7b/css/style.css
+++ b/libsite7b/css/style.css
@@ -2057,6 +2057,16 @@ section.pane .workshop-orientation-link {margin-top: .6em;}
 @media screen and (max-width:640px) {
   #block-views-libraries_events-block_1 { margin-top: -80px; }
 }
+
+/* prevent ugly float issues where subsequent labels aren't wrapping nicely due to unnecessary margins */
+.field-name-field-rsvp-url p {
+  margin: 0;
+}
+.field-name-field-event-date .date-display-single, .field-name-field-event-date .date-display-start, .field-name-field-event-date .date-display-end {
+  margin: 0;
+}
+
+
 /* end upcoming events */
 
 /* blog 'submitted by + date' formatting */

--- a/libsite7b/css/style.css
+++ b/libsite7b/css/style.css
@@ -2064,6 +2064,7 @@ section.pane .workshop-orientation-link {margin-top: .6em;}
 }
 .field-name-field-event-date .date-display-single, .field-name-field-event-date .date-display-start, .field-name-field-event-date .date-display-end {
   margin: 0;
+  line-height: normal;
 }
 
 


### PR DESCRIPTION
Events pages have had some weird wrapping issues (I think due to some combo of field type changes, historical mystery CSS, and Drupal class-itis). The changes committed here should hack together enough of a fix for #172, where Quinn gave examples of brokenness in various browsers.