### PR TITLE
T171 Removing links to the reports server in VSTC menu

### DIFF
--- a/libsite7b/templates/jsbottom.html
+++ b/libsite7b/templates/jsbottom.html
@@ -63,7 +63,6 @@
         $("#nav-eckles-hours").html("<a href='/eckles/hours' onClick=\"ga('send','event','primary-nav','/primary-nav/eckles/handheld/hours');\">Hours</a>");
 
         $("#nav-virginia-research").html("<a href='virginia/research' onClick=\"ga('send','event','primary-nav','/primary-nav/virginia/handheld/research');\">Research</a>");
-        $("#nav-virginia-collections").html("<a href='/virginia/collections' onClick=\"ga('send','event','primary-nav','/primary-nav/virginia/handheld/collections');\">Collections</a>");
         $("#nav-virginia-services").html("<a href='/virginia/services' onClick=\"ga('send','event','primary-nav','/primary-nav/virginia/handheld/services');\">Services</a>");
         $("#nav-virginia-news").html("<a href='/news-events' onClick=\"ga('send','event','primary-nav','/primary-nav/virginia/handheld-ios/news');\">News</a>");
         $("#nav-virginia-about").html("<a href='/virginia/about' onClick=\"ga('send','event','primary-nav','/primary-nav/virginia/handheld/about');\">About</a>");

--- a/libsite7b/templates/libnav.php
+++ b/libsite7b/templates/libnav.php
@@ -220,6 +220,7 @@
 							<li class='leaf'><a href='https://wrlc-gwu.primo.exlibrisgroup.com/discovery/search?vid=01WRLC_GWA:live'>Books, Articles and More</a></li>
 							<li class='leaf'><a href='https://wrlc-gwu.primo.exlibrisgroup.com/discovery/jsearch?vid=01WRLC_GWA:live'>Journals</a></li>
 							<li class='leaf'><a href='http://libguides.gwu.edu/databases'>Subject Databases</a><span class='leaf-extended'> | <a href='" . $front_page . "howdoi/findarticlesbytopic'>Tutorial</a></span></li>
+							<li class='leaf'><a href='https://wrlc-gwu.primo.exlibrisgroup.com/discovery/search?query=any,contains,nursing&tab=WRLC&search_scope=DiscoveryNetwork&sortby=date_d&vid=01WRLC_GWA:live&facet=library,include,4107%E2%80%93775147160004107&offset=0&came_from=sort'>Nursing Books at VSTCL</a></span></li>
 
 							<li class='first leaf leaf-section-title'>Research Guides</li>
 							<li class='leaf'><a href='http://libguides.gwu.edu/'>Subjects: </a><span class='leaf-extended'><a href='http://libguides.gwu.edu/content.php?pid=12823'>Art</a> | <a href='http://libguides.gwu.edu/content.php?pid=17054'>Psychology</a> | <a href='http://libguides.gwu.edu/'>More...</a></span></li>
@@ -230,18 +231,6 @@
 							<li class='leaf leaf-section-title'>Get Help</li>
 							<li class='leaf'><a href='" . $front_page . "virginia/reference'>Reference and Research Help</a></li>
 							<li class='leaf'><a href='" . $front_page . "howdoi'>How Do I? (Tutorials)</a></li>				
-						</ul>
-						</div>
-					</li>
-					
-					<li class='expanded nav-item' id=\"nav-virginia-collections\">
-						<a href='" . $front_page . "virginia/collections' onMouseOver=\"ga('send','event','primary-nav','/primary-nav/virginia/collections-hover',{'nonInteraction': 1});\">Collections</a>
-						<div class='sub-nav'>
-						<ul class='sub-menu-group'>
-							<li class='touch-show-nav touch-nav-main-link'><a href='" . $front_page . "virginia/collections'>COLLECTIONS</a></li>
-							<li class='first leaf'><a href='" . $front_page . "virginia/grants' title=''>Grants & Foundations</a></li>
-							<li class='leaf'><a href='http://reports.library.gwu.edu/virginiacampus/newbookshelf/'>New Books</a></li>
-							<li class='leaf'><a href='http://reports.library.gwu.edu/virginiacampus/virginiacollection/'>The Virginia Collection</a></li>		
 						</ul>
 						</div>
 					</li>
@@ -260,6 +249,7 @@
 							<li class='leaf'><a href='" . $front_page . "etd'>Electronic Theses & Dissertations</a></li>
 							<li class='leaf'><a href='" . $front_page . "virginia/reference'>Reference & Research Help</a></li>
 							<li class='leaf'><a href='" . $front_page . "virginia/computers'>Computers in the Library</a></li>
+							<li class='leaf'><a href='" . $front_page . "virginia/grants' title=''>Grants & Foundations</a></li>
 						</ul>	
 						</div>				
 					</li>


### PR DESCRIPTION
 * remove links to reports.library.gwu.edu in menus at /virginia/ pages
 * as Quinn discussed w/ Tara, move the "Grants & Foundations" link under "Library Services" in order to fully get rid of "Collections" menu (and ok that fewer than 6 items in mobile)
 * scope creep: add a link to VSTC Nursing Books in Primo (see ticket)

Fixes #171 (removal of "News & Events" discussed there being committed to another ticket's branch)